### PR TITLE
Change everything to static.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The plugin itself is pretty easy to use. Just call the method saveFile() with re
 
 ```dart
     await
-FileSaver.instance.saveFile(
+FileSaver.saveFile(
 
 String name, Uint8List
 bytes,
@@ -32,7 +32,7 @@ or you can call saveAs() _only available for android and iOS at the moment_
 
 ```dart
     await
-FileSaver.instance.saveAs(
+FileSaver.saveAs(
 
 String name, Uint8List
 bytes,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,7 +61,7 @@ class _MyAppState extends State<MyApp> {
                   List<int> sheets = await excel.encode();
                   Uint8List data = Uint8List.fromList(sheets);
                   MimeType type = MimeType.MICROSOFTEXCEL;
-                  String path = await FileSaver.instance.saveFile(
+                  String path = await FileSaver.saveFile(
                       textEditingController.text == ""
                           ? "File"
                           : textEditingController.text,
@@ -82,7 +82,7 @@ class _MyAppState extends State<MyApp> {
                     List<int> sheets = await excel.encode();
                     Uint8List data = Uint8List.fromList(sheets);
                     MimeType type = MimeType.MICROSOFTEXCEL;
-                    String path = await FileSaver.instance.saveAs(
+                    String path = await FileSaver.saveAs(
                         textEditingController.text == ""
                             ? "File"
                             : textEditingController.text,

--- a/lib/file_saver.dart
+++ b/lib/file_saver.dart
@@ -97,19 +97,16 @@ enum MimeType {
 class FileSaver {
   static const MethodChannel _channel = const MethodChannel('file_saver');
 
-  String _somethingWentWrong =
+  static String _somethingWentWrong =
       "Something went wrong, please report the issue https://www.github.com/incrediblezayed/file_saver/issues";
-  String _issueLink =
+  static String _issueLink =
       "https://www.github.com/incrediblezayed/file_saver/issues";
 
-  String _saveFile = "saveFile";
-  String _saveAs = "saveAs";
-
-  ///instance of file saver
-  static FileSaver get instance => FileSaver();
+  static String _saveFile = "saveFile";
+  static String _saveAs = "saveAs";
 
   ///This method will return String value of respective [MimeType]
-  String _getType(MimeType type) {
+  static String _getType(MimeType type) {
     switch (type) {
       case MimeType.AVI:
         return 'video/x-msvideo';
@@ -169,7 +166,7 @@ class FileSaver {
   }
 
   ///This method provides [Directory] for the file for Android, iOS, Linux, Windows, macOS
-  Future<String?> _getDirectory() async {
+  static Future<String?> _getDirectory() async {
     String? _path = "";
     try {
       if (Platform.isIOS) {
@@ -193,7 +190,7 @@ class FileSaver {
   }
 
   ///Open File Manager
-  Future<String> _openFileManager(Map<dynamic, dynamic> args) async {
+  static Future<String> _openFileManager(Map<dynamic, dynamic> args) async {
     String? _path = "Path: None";
     if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
       _path = await _channel.invokeMethod<String>(_saveAs, args);
@@ -213,7 +210,7 @@ class FileSaver {
   /// mimeType (Mainly required for web): MimeType from enum MimeType..
   ///
   /// More Mimetypes will be added in future
-  Future<String> saveFile(String name, Uint8List bytes, String ext,
+  static Future<String> saveFile(String name, Uint8List bytes, String ext,
       {MimeType mimeType = MimeType.OTHER}) async {
     String mime = _getType(mimeType);
     String _directory = _somethingWentWrong;
@@ -272,7 +269,7 @@ class FileSaver {
   ///
   /// More Mimetypes will be added in future
   /// Note:- This Method only works on Android for time being and other platforms will be added soon
-  Future<String> saveAs(
+  static Future<String> saveAs(
       String name, Uint8List bytes, String ext, MimeType mimeType) async {
     String _mimeType = _getType(mimeType);
     Map<dynamic, dynamic> data = {

--- a/lib/file_saver_web.dart
+++ b/lib/file_saver_web.dart
@@ -19,11 +19,10 @@ class FileSaverWeb {
       registrar,
     );
 
-    final pluginInstance = FileSaverWeb();
-    channel.setMethodCallHandler(pluginInstance.handleMethodCall);
+    channel.setMethodCallHandler(handleMethodCall);
   }
 
-  Future<dynamic> handleMethodCall(MethodCall call) async {
+  static Future<dynamic> handleMethodCall(MethodCall call) async {
     switch (call.method) {
       case 'saveFile':
         String args = call.arguments;
@@ -43,7 +42,7 @@ class FileSaverWeb {
     }
   }
 
-  Future<bool> downloadFile(Uint8List bytes, String name, String type) async {
+  static Future<bool> downloadFile(Uint8List bytes, String name, String type) async {
     bool _success = false;
 
     try {


### PR DESCRIPTION
Now is not needed to call methods from FileSaver.instance, it works from FileSaver directly.

Instead of FileSaver.instance.saveFile(...) now goes FileSaver.saveFile(...)

Lightly tested with example app on web and Android.