### PR TITLE
Bugfix - Android no return if picker is dismissed

### DIFF
--- a/android/src/main/kotlin/com/one/file_saver/Dialog.kt
+++ b/android/src/main/kotlin/com/one/file_saver/Dialog.kt
@@ -29,14 +29,21 @@ class Dialog(private val activity: Activity) : PluginRegistry.ActivityResultList
     private var fileName: String? = null
     private val TAG = "Dialog Activity"
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
-        if (requestCode == SAVE_FILE &&  resultCode == Activity.RESULT_OK && data?.data != null) {
-            Log.d(TAG, "Starting file operation")
-            completeFileOperation(data.data!!)
+       if (requestCode == SAVE_FILE) {
+            if(resultCode == Activity.RESULT_OK && data?.data != null) {
+                Log.d(TAG, "Starting file operation")
+                completeFileOperation(data.data!!)
+                return true;
+            } else {
+                Log.d(TAG, "Activity result null")
+                result?.success("")
+                return false
+            }
         } else {
-            Log.d(TAG, "Activity result was null")
+            Log.d(TAG, "Unsupported activity result")
+            result?.error("Unsupported activity result", "request: " + requestCode + ", result: " + resultCode, null)
             return false
         }
-        return true
     }
 
     fun openFileManager(


### PR DESCRIPTION
First thank you very much for this plugin. It works very well.

I found one small problem: If you cancel the process of saving a file on android with `FileSaver.instance.saveAs` and you dismiss the folder selection, the method never returns.