### PR TITLE
Update pubspec.yaml to support Dart 3.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,8 @@ version: 0.2.2
 repository: https://github.com/incrediblezayed/file_saver
 
 environment:
-  sdk: ">=2.17.0 <3.0.2"
-  flutter: ">=1.20.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
As the latest Beta of Flutter 3.11.0 runs on Dart 3.1, file_saver was no longer compatible because of the sdk constraints.

I increased the constraints to support any sdk version lower than 4.0.0. And set the minimum flutter version to 3.0.0 as well.
