### PR TITLE
Add apng mime type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.5]
+ * Added apng mime type
+
 ## [0.2.4]
  * Bug Fix -> Link Details not available publically
 

--- a/lib/src/utils/mime_types.dart
+++ b/lib/src/utils/mime_types.dart
@@ -9,6 +9,9 @@ enum MimeType {
     type: 'audio/aac',
   ),
 
+  ///[apng] for .apng extension
+  apng(name: 'APNG', type: 'image/apng'),
+
   ///[asice] for .asice
   asice(name: 'ASICE', type: 'application/vnd.etsi.asic-e+zip'),
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_saver
 description: >-
   This package will help you save file with a single method on any platform
   including macOS, iOS, Android, Windows, Web, Linux.
-version: 0.2.4
+version: 0.2.5
 repository: https://github.com/incrediblezayed/file_saver
 
 environment:


### PR DESCRIPTION
Adds `MimeType.apng` enum value.

BTW I don't think using enums for MimeType is a good idea. It seems the fact that it's an enum is (practically) never used and requires forking a package whenever mime type needed is not included