### PR TITLE
Add initial support to Windows

### DIFF
--- a/lib/src/platform_handler/platform_handler_all.dart
+++ b/lib/src/platform_handler/platform_handler_all.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:file_saver/src/models/file.model.dart';
 import 'package:file_saver/src/platform_handler/platform_handler.dart';
@@ -67,6 +68,9 @@ class PlatformHandlerAll extends PlatformHandler {
     String? path;
     if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
       path = await _channel.invokeMethod<String>(_saveAs, fileModel.toMap());
+    } else if (Platform.isWindows) {
+      final Int64List? bytes = await _channel.invokeMethod<Int64List?>('saveAs', fileModel.toMap());
+      path = bytes == null ? null : String.fromCharCodes(bytes);
     } else {
       throw UnimplementedError('Unimplemented Error');
     }

--- a/windows/file_saver_plugin.cpp
+++ b/windows/file_saver_plugin.cpp
@@ -6,6 +6,8 @@
 // For getPlatformVersion; remove unless needed for your plugin implementation.
 #include <VersionHelpers.h>
 
+#include <Commdlg.h>
+
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
@@ -13,6 +15,7 @@
 #include <map>
 #include <memory>
 #include <sstream>
+#include <algorithm>
 
 namespace {
 
@@ -53,12 +56,68 @@ FileSaverPlugin::FileSaverPlugin() {}
 
 FileSaverPlugin::~FileSaverPlugin() {}
 
+std::vector<int64_t> WideStringToVector(const wchar_t* wideStr) {
+  std::vector<int64_t> result;
+
+  int length = 0;
+  while (wideStr[length] != L'\0') {
+    length++;
+  }
+
+  for (int i = 0; i < length; i++) {
+    result.push_back(static_cast<int64_t>(wideStr[i]));
+  }
+
+  return result;
+}
+
+std::wstring FileExtensionToFileFilter(std::string fileExtension) {
+  std::string fileExtensionName = fileExtension.substr(1);
+  for (auto& c : fileExtensionName) c = (char) std::toupper(c);
+
+  std::wstring wideFileExtension = std::wstring(fileExtension.begin(), fileExtension.end());
+  std::wstring wideFileExtensionName = std::wstring(fileExtensionName.begin(), fileExtensionName.end());
+  return wideFileExtensionName + L" File\0*." + wideFileExtensionName + L"\0\0";
+}
+
 void FileSaverPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
   if (method_call.method_name().compare("saveAs") == 0) {
-    
-    result->Success(flutter::EncodableValue('f'));
+    const auto& arguments = *method_call.arguments();
+    const auto& mapArgs = std::get<flutter::EncodableMap>(arguments);
+
+    const flutter::EncodableValue& inputFileNameValue = mapArgs.at(flutter::EncodableValue("name"));
+    const std::string inputFileName = std::get<std::string>(inputFileNameValue);
+
+    const flutter::EncodableValue& inputExtensionValue = mapArgs.at(flutter::EncodableValue("ext"));
+    const std::string inputExtension = std::get<std::string>(inputExtensionValue);
+
+    const std::string defaultFileName = inputFileName + inputExtension;
+    static wchar_t szFile[MAX_PATH] = L"";
+    wcscpy_s(szFile, std::wstring(defaultFileName.begin(), defaultFileName.end()).c_str());
+
+    const std::wstring defaultFileFilter = FileExtensionToFileFilter(inputExtension);
+    static wchar_t lpstrFilter[MAX_PATH] = L"";
+    wcscpy_s(lpstrFilter, defaultFileFilter.c_str());
+
+    OPENFILENAME ofn;
+    ZeroMemory(&ofn, sizeof(ofn));
+    ofn.lStructSize = sizeof(ofn);
+    ofn.hwndOwner = NULL;
+    // ofn.lpstrFilter = L"All Files\0*.*\0";
+    ofn.lpstrFilter = lpstrFilter;
+    ofn.lpstrFile = szFile;
+    ofn.nMaxFile = MAX_PATH;
+    ofn.Flags = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
+
+    if (GetSaveFileName(&ofn)) {
+      std::vector<int64_t> value = WideStringToVector(szFile);
+      result->Success(flutter::EncodableValue(value));
+    } else {
+      result->Success(flutter::EncodableValue());
+    }
+
   } else {
     result->NotImplemented();
   }


### PR DESCRIPTION
Uses the [OPENFILENAMEA structure](https://learn.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamea) of Windows API to open a "Save as" dialog on Windows, allowing the user to select a directory, where its path will be returned from `saveAs`.

This PR 

- *does* assign the "Name" field of the dialog to the `name` and `ext` passed to `saveAs`
- *does not* (properly) assign the "Type" field of the dialog, represented by `lpstrFilter` on Windows API
- *does not* save the file inside the `saveAs` call. The user must still do

  ```dart
  final String? path = await FileSaver.instance.saveAs(bytes: bytes, /* ... */);
  if (path == null) return;

  await File(path).writeAsBytes(bytes);
  ```

Hope this helps in some way, since it's a MVP. Any contribution is welcome!
