### PR TITLE
add asCopy param in UIDocumentPickerViewController

### DIFF
--- a/ios/Classes/Dialog.swift
+++ b/ios/Classes/Dialog.swift
@@ -36,7 +36,7 @@ class Dialog:NSObject, UIDocumentPickerDelegate {
         self.tempURL = fileURL
         var docPicker: UIDocumentPickerViewController?
         if #available(iOS 14.0, *) {
-            docPicker = UIDocumentPickerViewController(forExporting: [fileURL!])
+            docPicker = UIDocumentPickerViewController(forExporting: [fileURL!], asCopy: true)
         } else {
             docPicker = UIDocumentPickerViewController(url: fileURL!, in: .exportToService)
         }


### PR DESCRIPTION
When the users try to saveAs in ios, the Files app pop up and let the users select a path to save the file. However, the move button in this dialog in ios makes users confused. The users doesn't know what to do until they press on move button.
![Screenshot 2023-12-21 at 1 53 55 pm](https://github.com/incrediblezayed/file_saver/assets/934966/54123fa3-1ed7-4fe9-8c78-5b3a899f372a)
