### PR TITLE
Remove unnecessary create document intent parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.10]
+ * Fixed ([GitHub issue #95](https://github.com/incrediblezayed/file_saver/issues/95))
+
 ## [0.2.9]
  * Merged PR [#75](https://github.com/incrediblezayed/file_saver/pull/81) resolving issue [#75][https://github.com/incrediblezayed/file_saver/issues/75]
  * Merged PR [#79](https://github.com/incrediblezayed/file_saver/pull/79) resolving issue [#78](https://github.com/incrediblezayed/file_saver/issues/78)

--- a/android/src/main/kotlin/com/incrediblezayed/file_saver/Dialog.kt
+++ b/android/src/main/kotlin/com/incrediblezayed/file_saver/Dialog.kt
@@ -55,20 +55,13 @@ class Dialog(private val activity: Activity) : PluginRegistry.ActivityResultList
         this.fileName = fileName
         val intent =
             Intent(Intent.ACTION_CREATE_DOCUMENT)
-        intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true)
         intent.addCategory(Intent.CATEGORY_OPENABLE)
         intent.putExtra(Intent.EXTRA_TITLE, "$fileName.$ext")
-        intent.putExtra(Intent.EXTRA_MIME_TYPES, type)
         intent.putExtra(
             DocumentsContract.EXTRA_INITIAL_URI,
             Environment.getExternalStorageDirectory().path
         )
         intent.type = type
-        intent.flags = (Intent.FLAG_GRANT_READ_URI_PERMISSION
-                or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
-                or Intent.FLAG_GRANT_PREFIX_URI_PERMISSION
-                )
         activity.startActivityForResult(intent, SAVE_FILE)
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_saver
 description: >-
   This package will help you save file with a single method on any platform
   including macOS, iOS, Android, Windows, Web, Linux.
-version: 0.2.9
+version: 0.2.10
 repository: https://github.com/incrediblezayed/file_saver
 homepage: https://hassanansari.dev
 


### PR DESCRIPTION
Resolves issue #95.

I'm not quite sure about removing `Intent.FLAG_GRANT_WRITE_URI_PERMISSION` flag but we are doing exactly what is described [here](https://developer.android.com/training/data-storage/shared/documents-files#create-file) and no permission flags are mentioned 